### PR TITLE
feat: Create American Commonwealth

### DIFF
--- a/common/coat_of_arms/coat_of_arms/mod_COA.txt
+++ b/common/coat_of_arms/coat_of_arms/mod_COA.txt
@@ -2,3 +2,10 @@ NULL = {
 	pattern = "pattern_solid.tga"
 	color1 = "grey_observer"
 }
+
+ACW = {
+	pattern = "pattern_solid.tga"
+	color1 = { 128 0 128 }
+	color2 = "white"
+	color3 = "black"
+}

--- a/common/country_definitions/99_acw.txt
+++ b/common/country_definitions/99_acw.txt
@@ -1,0 +1,7 @@
+ACW = {
+	color = { 128 0 128 }
+	country_type = recognized
+	tier = kingdom
+	cultures = { yankee dixie }
+	capital = STATE_NEW_YORK
+}

--- a/common/history/buildings/05_north_america.txt
+++ b/common/history/buildings/05_north_america.txt
@@ -1,11 +1,11 @@
 ﻿BUILDINGS={
 	s:STATE_DISTRICT_OF_COLUMBIA={
-		region_state:USA={
+		region_state:ACW={
 			create_building={
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=6
 					}
 				}
@@ -23,7 +23,7 @@
 			has_american_buildings_dlc_trigger = yes
 		}
 		s:STATE_DISTRICT_OF_COLUMBIA={
-			region_state:USA={
+			region_state:ACW={
 				create_building={
 					building="building_capitol_hill"
 					level=1
@@ -86,12 +86,12 @@
 		}
 	}
 	s:STATE_NEW_YORK={
-		region_state:USA={
+		region_state:ACW={
 			create_building={
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=10
 					}
 				}
@@ -104,7 +104,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=10
 						region="STATE_NEW_YORK"
 					}
@@ -115,7 +115,7 @@
 				building="building_construction_sector"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 					}
 				}
@@ -126,7 +126,7 @@
 				building="building_university"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 					}
 				}
@@ -138,7 +138,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=4
 						region="STATE_NEW_YORK"
 					}
@@ -151,12 +151,12 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NEW_YORK"
 					}
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -168,7 +168,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=5
 						region="STATE_NEW_YORK"
 					}
@@ -181,7 +181,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_NEW_YORK"
 					}
@@ -194,7 +194,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=5
 						region="STATE_NEW_YORK"
 					}
@@ -207,7 +207,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_NEW_YORK"
 					}
@@ -220,13 +220,13 @@
 				add_ownership={
 					building={
 						type="building_wheat_farm"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_NEW_YORK"
 					}
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NEW_YORK"
 					}
@@ -239,13 +239,13 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NEW_YORK"
 					}
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NEW_YORK"
 					}
@@ -258,7 +258,7 @@
 				add_ownership={
 					building={
 						type="building_fishing_wharf"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_NEW_YORK"
 					}
@@ -270,7 +270,7 @@
 				building="building_port"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 					}
 				}
@@ -284,7 +284,7 @@
 			has_american_buildings_dlc_trigger = yes
 		}
 		s:STATE_NEW_YORK={
-			region_state:USA={
+			region_state:ACW={
 				create_building={
 					building="building_central_park"
 					level=1
@@ -293,12 +293,12 @@
 		}
 	}
 	s:STATE_VIRGINIA={
-		region_state:USA={
+		region_state:ACW={
 			create_building={
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 					}
 				}
@@ -310,12 +310,12 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_VIRGINIA"
 					}
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -327,7 +327,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_VIRGINIA"
 					}
@@ -340,13 +340,13 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_VIRGINIA"
 					}
 					building={
 						type="building_maize_farm"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_VIRGINIA"
 					}
@@ -359,7 +359,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_VIRGINIA"
 					}
@@ -372,7 +372,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=4
 						region="STATE_VIRGINIA"
 					}
@@ -385,7 +385,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=7
 						region="STATE_VIRGINIA"
 					}
@@ -398,7 +398,7 @@
 				add_ownership={
 					building={
 						type="building_shipyards"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_VIRGINIA"
 					}
@@ -410,7 +410,7 @@
 				building="building_military_shipyards"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -421,7 +421,7 @@
 				building="building_port"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 					}
 				}
@@ -610,7 +610,7 @@
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -697,7 +697,7 @@
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 					}
 				}
@@ -806,7 +806,7 @@
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -941,7 +941,7 @@
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1051,7 +1051,7 @@
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1143,7 +1143,7 @@
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1198,12 +1198,12 @@
 		}
 	}
 	s:STATE_ALABAMA={
-		region_state:USA={
+		region_state:ACW={
 			create_building={
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1215,13 +1215,13 @@
 				add_ownership={
 					building={
 						type="building_maize_farm"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_ALABAMA"
 					}
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_ALABAMA"
 					}
@@ -1234,7 +1234,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_ALABAMA"
 					}
@@ -1247,7 +1247,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=10
 						region="STATE_ALABAMA"
 					}
@@ -1260,7 +1260,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_ALABAMA"
 					}
@@ -1272,7 +1272,7 @@
 				building="building_port"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1282,16 +1282,16 @@
 		}
 	}
 	s:STATE_FLORIDA={
-		region_state:USA={
+		region_state:ACW={
 		}
 	}
 	s:STATE_GEORGIA={
-		region_state:USA={
+		region_state:ACW={
 			create_building={
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 					}
 				}
@@ -1303,13 +1303,13 @@
 				add_ownership={
 					building={
 						type="building_maize_farm"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_GEORGIA"
 					}
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_GEORGIA"
 					}
@@ -1322,7 +1322,7 @@
 				add_ownership={
 					building={
 						type="building_livestock_ranch"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_GEORGIA"
 					}
@@ -1335,7 +1335,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_GEORGIA"
 					}
@@ -1348,7 +1348,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=8
 						region="STATE_GEORGIA"
 					}
@@ -1361,7 +1361,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_GEORGIA"
 					}
@@ -1373,7 +1373,7 @@
 				building="building_port"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1418,7 +1418,7 @@
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1431,7 +1431,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_MARYLAND"
 					}
@@ -1443,7 +1443,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_MARYLAND"
 					}
@@ -1456,7 +1456,7 @@
 				add_ownership={
 					building={
 						type="building_fishing_wharf"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_MARYLAND"
 					}
@@ -1469,7 +1469,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=4
 						region="STATE_MARYLAND"
 					}
@@ -1481,7 +1481,7 @@
 				building="building_port"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 					}
 				}
@@ -1491,12 +1491,12 @@
 		}
 	}
 	s:STATE_DELAWARE={
-		region_state:USA={
+		region_state:ACW={
 			create_building={
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1508,7 +1508,7 @@
 				add_ownership={
 					building={
 						type="building_fishing_wharf"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_DELAWARE"
 					}
@@ -1521,7 +1521,7 @@
 				add_ownership={
 					building={
 						type="building_livestock_ranch"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_DELAWARE"
 					}
@@ -1532,12 +1532,12 @@
 		}
 	}
 	s:STATE_PENNSYLVANIA={
-		region_state:USA={
+		region_state:ACW={
 			create_building={
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 					}
 				}
@@ -1550,7 +1550,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1562,7 +1562,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1574,7 +1574,7 @@
 				building="building_construction_sector"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 					}
 				}
@@ -1586,7 +1586,7 @@
 				add_ownership={
 					building={
 						type="building_textile_mills"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1599,13 +1599,13 @@
 				add_ownership={
 					building={
 						type="building_furniture_manufacturies"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_PENNSYLVANIA"
 					}
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1617,7 +1617,7 @@
 				building="building_munition_plants"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1629,7 +1629,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1642,7 +1642,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=4
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1655,13 +1655,13 @@
 				add_ownership={
 					building={
 						type="building_maize_farm"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_PENNSYLVANIA"
 					}
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1674,7 +1674,7 @@
 				add_ownership={
 					building={
 						type="building_tooling_workshops"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1687,7 +1687,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1700,7 +1700,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1713,13 +1713,13 @@
 				add_ownership={
 					building={
 						type="building_livestock_ranch"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_PENNSYLVANIA"
 					}
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1732,13 +1732,13 @@
 				add_ownership={
 					building={
 						type="building_logging_camp"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_PENNSYLVANIA"
 					}
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1751,7 +1751,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_PENNSYLVANIA"
 					}
@@ -1764,7 +1764,7 @@
 				add_ownership={
 					company={
 						type=company_william_cramp
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1781,7 +1781,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NEW_JERSEY"
 					}
@@ -1793,12 +1793,12 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NEW_JERSEY"
 					}
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 					}
 				}
@@ -1809,7 +1809,7 @@
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1821,7 +1821,7 @@
 				add_ownership={
 					company={
 						type=company_william_cramp
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -1833,7 +1833,7 @@
 				add_ownership={
 					building={
 						type="building_fishing_wharf"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NEW_JERSEY"
 					}
@@ -1846,7 +1846,7 @@
 				add_ownership={
 					building={
 						type="building_maize_farm"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NEW_JERSEY"
 					}
@@ -1859,7 +1859,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_NEW_JERSEY"
 					}
@@ -1936,7 +1936,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_RHODE_ISLAND"
 					}
@@ -1949,7 +1949,7 @@
 				add_ownership={
 					building={
 						type="building_fishing_wharf"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_RHODE_ISLAND"
 					}
@@ -1977,7 +1977,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_CONNECTICUT"
 					}
@@ -1989,7 +1989,7 @@
 				building="building_port"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -2017,7 +2017,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=5
 						region="STATE_MASSACHUSETTS"
 					}
@@ -2028,7 +2028,7 @@
 				building="building_construction_sector"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -2039,7 +2039,7 @@
 				building="building_university"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 					}
 				}
@@ -2051,13 +2051,13 @@
 				add_ownership={
 					building={
 						type="building_textile_mills"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_MASSACHUSETTS"
 					}
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_MASSACHUSETTS"
 					}
@@ -2070,7 +2070,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_MASSACHUSETTS"
 					}
@@ -2083,7 +2083,7 @@
 				add_ownership={
 					company={
 						type=company_william_cramp
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 					}
 				}
@@ -2095,7 +2095,7 @@
 				add_ownership={
 					building={
 						type="building_fishing_wharf"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_MASSACHUSETTS"
 					}
@@ -2108,7 +2108,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_MASSACHUSETTS"
 					}
@@ -2121,13 +2121,13 @@
 				add_ownership={
 					building={
 						type="building_wheat_farm"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_MASSACHUSETTS"
 					}
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_MASSACHUSETTS"
 					}
@@ -2139,7 +2139,7 @@
 				building="building_port"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 					}
 				}
@@ -2151,7 +2151,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_MASSACHUSETTS"
 					}
@@ -2179,7 +2179,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NEW_HAMPSHIRE"
 					}
@@ -2192,7 +2192,7 @@
 				add_ownership={
 					building={
 						type="building_livestock_ranch"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NEW_HAMPSHIRE"
 					}
@@ -2209,7 +2209,7 @@
 				add_ownership={
 					building={
 						type="building_food_industry"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_VERMONT"
 					}
@@ -2222,7 +2222,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_VERMONT"
 					}
@@ -2235,7 +2235,7 @@
 				add_ownership={
 					building={
 						type="building_livestock_ranch"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_VERMONT"
 					}
@@ -2263,7 +2263,7 @@
 				add_ownership={
 					building={
 						type="building_furniture_manufacturies"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_MAINE"
 					}
@@ -2276,7 +2276,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_MAINE"
 					}
@@ -2289,7 +2289,7 @@
 				add_ownership={
 					company={
 						type=company_william_cramp
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -2301,7 +2301,7 @@
 				add_ownership={
 					building={
 						type="building_fishing_wharf"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_MAINE"
 					}
@@ -2313,7 +2313,7 @@
 				building="building_port"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -2328,7 +2328,7 @@
 				building="building_government_administration"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 					}
 				}
@@ -2340,7 +2340,7 @@
 				add_ownership={
 					building={
 						type="building_food_industry"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NORTH_CAROLINA"
 					}
@@ -2353,7 +2353,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_NORTH_CAROLINA"
 					}
@@ -2366,7 +2366,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 						region="STATE_NORTH_CAROLINA"
 					}
@@ -2379,13 +2379,13 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_NORTH_CAROLINA"
 					}
 					building={
 						type="building_maize_farm"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_NORTH_CAROLINA"
 					}
@@ -2398,7 +2398,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=10
 						region="STATE_NORTH_CAROLINA"
 					}
@@ -2410,7 +2410,7 @@
 				building="building_port"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}
@@ -2446,7 +2446,7 @@
 				add_ownership={
 					building={
 						type="building_financial_district"
-						country="c:USA"
+						country="c:ACW"
 						levels=6
 						region="STATE_MASSACHUSETTS"
 					}
@@ -2458,7 +2458,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=10
 						region="STATE_SOUTH_CAROLINA"
 					}
@@ -2471,7 +2471,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=5
 						region="STATE_SOUTH_CAROLINA"
 					}
@@ -2484,7 +2484,7 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_SOUTH_CAROLINA"
 					}
@@ -2497,13 +2497,13 @@
 				add_ownership={
 					building={
 						type="building_manor_house"
-						country="c:USA"
+						country="c:ACW"
 						levels=2
 						region="STATE_SOUTH_CAROLINA"
 					}
 					building={
 						type="building_maize_farm"
-						country="c:USA"
+						country="c:ACW"
 						levels=3
 						region="STATE_SOUTH_CAROLINA"
 					}
@@ -2515,7 +2515,7 @@
 				building="building_port"
 				add_ownership={
 					country={
-						country="c:USA"
+						country="c:ACW"
 						levels=1
 					}
 				}

--- a/common/history/countries/acw_commonwealth.txt
+++ b/common/history/countries/acw_commonwealth.txt
@@ -1,0 +1,10 @@
+COUNTRIES = {
+	c:ACW = {
+		effect_starting_technology_tier_6_tech = yes
+		effect_starting_politics_traditional = yes
+		effect_native_conscription_10 = yes
+	}
+	c:GBR = {
+		set_puppet = c:ACW
+	}
+}

--- a/common/history/pops/05_north_america.txt
+++ b/common/history/pops/05_north_america.txt
@@ -4,7 +4,7 @@
 		# + Fairfax County, VA. Total pop in 1830 was 9204, 5203 free/4001 slaves
 		# + Montgomery Co, Prince George's Co, Charles co, St. Mary's Co and Calvert Co in MD- 80418 total, 42176 free/38242 slaves
 		# Number of actual pops adjusted from historical research to better fit the buildings
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = yankee
 				size = 27544
@@ -54,7 +54,7 @@
 		}
 	}
 	s:STATE_NEW_YORK = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = yankee
 				size = 2135000
@@ -84,7 +84,7 @@
 		}
 	}
 	s:STATE_VIRGINIA = { # population of VA proper minus Fairfax County, which had its population figures added to DC to inflate the pop count there
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = dixie
 				size = 423597
@@ -697,7 +697,7 @@
 		}
 	}
 	s:STATE_FLORIDA = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = dixie
 				size = 47996
@@ -751,7 +751,7 @@
 		}
 	}
 	s:STATE_WEST_VIRGINIA = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = dixie
 				size = 160916
@@ -773,7 +773,7 @@
 		}
 	}
 	s:STATE_MARYLAND = { # Actually Maryland + Delaware
-		region_state:USA = {
+		region_state:ACW = {
 			# Maryland: (1830, 447040) (1840, 470019), so 1835 est. 458530
 			# Delaware: (1830, 76748)  (1840, 78085),  so 1835 est. 77417
 			# minus 42176 free/38242 slaves that have been ceded to DC to inflate its pop figure
@@ -819,7 +819,7 @@
 	}
 
 	s:STATE_PENNSYLVANIA = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = yankee
 				size = 1250496
@@ -845,7 +845,7 @@
 		}
 	}
 	s:STATE_NEW_JERSEY = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = yankee
 				size = 303200
@@ -874,7 +874,7 @@
 		}
 	}
 	s:STATE_RHODE_ISLAND = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = yankee
 				size = 104820
@@ -882,7 +882,7 @@
 		}
 	}
 	s:STATE_CONNECTICUT = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = yankee
 				size = 199228
@@ -890,7 +890,7 @@
 		}
 	}
 	s:STATE_MASSACHUSETTS = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = yankee
 				size = 754484
@@ -911,7 +911,7 @@
 		}
 	}
 	s:STATE_NEW_HAMPSHIRE = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = yankee
 				size = 223300
@@ -928,7 +928,7 @@
 		}
 	}
 	s:STATE_VERMONT = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = yankee
 				size = 282848
@@ -936,7 +936,7 @@
 		}
 	}
 	s:STATE_MAINE = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = anglo_canadian
 				size = 16000
@@ -948,7 +948,7 @@
 		}
 	}
 	s:STATE_NORTH_CAROLINA = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = dixie
 				size = 492500
@@ -993,7 +993,7 @@
 		}
 	}
 	s:STATE_SOUTH_CAROLINA = {
-		region_state:USA = {
+		region_state:ACW = {
 			create_pop = {
 				culture = dixie
 				size = 253836

--- a/common/history/states/00_states.txt
+++ b/common/history/states/00_states.txt
@@ -24,7 +24,7 @@ STATES = {
 	}
 	s:STATE_NEW_YORK = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x1BAD55 x377E55 xFC18F1 xDB0967 x99CB10 xB08000 xD534B1 x75F2A6 x300080 x38C881 x260926 x9CC56A x4B0747 xBA53D0 x70C080 x195B49 xE217B5 x8C059D xB343E6 x308000 x2CA754 xE7BE2D x01D042 xB00080 xA6BED5 x235E9F xEDC7DA x3CB274 x73A16C x42D496 xFCF1BE xA7B5FE x05187E x9484F3 xEC2EAA }
 		}
 
@@ -33,7 +33,7 @@ STATES = {
 	}
 	s:STATE_VIRGINIA = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { xC0B0C0 x50F06C x90316A xC8ABE0 x4BD8B5 x056BA1 x76D2B5 xB5B538 xF00080 x304080 xBF8CE2 x40B0C0 x79AC2A x806B93 x9D6816 xB0C000 xAA8809 x08C98C xF13564 xC070C0 x29E263 x355247 x8D147E x8E2B78 x95CEBC xF47C46 x764809 x7C5B12 }
 		}
 
@@ -636,7 +636,7 @@ STATES = {
 	}
 	s:STATE_FLORIDA = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = {
 				x4407A0 x5B1199 xED77FB xE58A3D x5CD014 x7BCB55 xC60D66 x4070C0 x3556E5 xAAF2AF xF0B481 x9088D5 xFE627B x65ECBE xC000F0 x2E5E47 x3126CA x88BDEA x31C481 xB06E20 xDAE3CC x0C1D7F x1714EE xA03000 xD0761D x23B4D0 x8C16F9 x6E31DE x976584 xE3533E
 			}
@@ -656,7 +656,7 @@ STATES = {
 	}
 	s:STATE_GEORGIA = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x407040 xE631D3 xB3D9D8 x169E1F xCB1A53 xA86682 x7B295A x3D2D7D x4EA3CA x14A138 x98A030 x6D8A9F xCD4C42 xA496A6 xFD85D7 xC07040 xE933F3 xEE9338 x476DE4 xC2859C x19EFC6 x391CFA x40F040 x13B302 x56DBDA x69FAA9 xE2E34A xBE8916 x9BEA44 x802080 xABCC5E x39E367 xBDB2BA x21E256 xFCECD3 xF0CB48 xD66E1C }
 		}
 
@@ -665,7 +665,7 @@ STATES = {
 	}
 	s:STATE_DISTRICT_OF_COLUMBIA = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x700080 x44578c }
 		}
 
@@ -673,7 +673,7 @@ STATES = {
 	}
 	s:STATE_WEST_VIRGINIA = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x579843 x845FC0 xCB120B xB865A2 x82CE19 x0F5821 x366DF2 x999738 x38925B x06D57E x30C000 x7416CB xB04000 x2EA16C x364F38 x43DB99 x7755AD x08D472 xAD371C }
 		}
 
@@ -681,7 +681,7 @@ STATES = {
 	}
 	s:STATE_MARYLAND = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x708080 x0E3435 xAEB9F5 xF08000 x16482D x5E6C0F x888194 x576240 x3CC08F }
 		}
 
@@ -690,7 +690,7 @@ STATES = {
 
 	s:STATE_DELAWARE = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x708000 xeba646 }
 		}
 
@@ -699,7 +699,7 @@ STATES = {
 
 	s:STATE_PENNSYLVANIA = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { xB00000 x703866 x75195D xDD6B3C xAF1AEE x308080 xACC198 x4CB9DF xF08080 x038B77 xBC1A94 x345319 x0804CE xB7EDCF x56401E xCDBD85 x265ADC xC786AB x976E86 xF1C228 xC0C080 x242311 x501463 x7CF534 xAC9DC0 x67DB6F xE2ACEE x691121 x413E60 x6C494D x8C787A x533151 xC4DED4 x606D4F }
 		}
 
@@ -707,7 +707,7 @@ STATES = {
 	}
 	s:STATE_NEW_JERSEY = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { xF00000 x503169 x552873 xA14B4E x716F90 }
 		}
 
@@ -723,7 +723,7 @@ STATES = {
 	}
 	s:STATE_CONNECTICUT = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x3040C0 x7DE678 x9D3A73 }
 		}
 
@@ -731,7 +731,7 @@ STATES = {
 	}
 	s:STATE_RHODE_ISLAND = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x939ACE x1A77EA xc5ce93 }
 		}
 
@@ -739,7 +739,7 @@ STATES = {
 	}
 	s:STATE_MASSACHUSETTS = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { xA58ED2 x211ECF x13444D x382709 xB040C0 x8D8744 }
 		}
 
@@ -747,7 +747,7 @@ STATES = {
 	}
 	s:STATE_VERMONT = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { xB0C040 x34FFC4 x142566 x30F1AF x3FA10D x38CCDA }
 		}
 
@@ -755,7 +755,7 @@ STATES = {
 	}
 	s:STATE_NEW_HAMPSHIRE = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x30C040 xBB7965 x1DC591 xDB930D x3E6BAD xD871BE x2B5499 xB16D83 x92CF0F }
 		}
 
@@ -763,7 +763,7 @@ STATES = {
 	}
 	s:STATE_MAINE = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x6B3A42 xF2502E x1CA7B0 xBD7C03 x6AE419 xC2B02B xC4CDFC x8F9450 xD68A28 x990681 x54816B xD64964 xEFC355 x7182E8 xFBEDD6 x8243C0 x59DEDF xFB9715 x262924 x6E757B xFCFF52 xF080C0 xA5DE9D x441473 x5806F4 x1E33E8 xB04040 }
 		}
 
@@ -771,7 +771,7 @@ STATES = {
 	}
 	s:STATE_NORTH_CAROLINA = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x807040 x7BF507 xDBBF9F x5961F9 xD8D851 xF3C9D3 xD01C13 x785402 x644A75 x58A1C9 x8070C0 x5B809B x7F5918 x0F9A00 x7DE315 x81AAED x007040 x7342E7 x1B47BD x4DC66C x711CB6 xE5DA13 xC58DAF xA59977 x3EA432 x00F040 xABF402 x228851 x338BD7 x6FBF63 x3C4F8A x758494 }
 		}
 
@@ -7834,7 +7834,7 @@ STATES = {
 	}
 	s:STATE_SOUTH_CAROLINA = {
 		create_state = {
-			country = c:USA
+			country = c:ACW
 			owned_provinces = { x31E5D4 xE2F040 x8E69FE xAF8C38 x2C6AA0 x47BF09 x007602 xF5B3A1 x7AAA59 x0070C0 xF83D99 x8998F6 xD641CB xF93340 x3B0FAE x6F7B23 x1FA379 x9B1B8B xD4D27E }
 		}
 


### PR DESCRIPTION
This commit introduces the American Commonwealth as a new country in the mod.

- The American Commonwealth (ACW) is a puppet of Great Britain.
- It owns the east coast states of the USA.
- It has a purple map color and a plain purple flag.
- The population and building data has been updated to reflect the new ownership.

The start date could not be changed to 1803 as the relevant file could not be located in the mod's file structure.